### PR TITLE
Scaffold Next.js frontend

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# coherenceism.info
+# Coherenceism Frontend
+
+This repo hosts the Next.js frontend for **Coherenceism.info**. Content is stored in the separate `coherenceism.content` repository and will be pulled in during build time or runtime.
+
+## Project Structure
+
+```
+/app/           - App Router pages and layouts
+/components/    - Reusable UI components
+/lib/           - Server/client utilities
+/public/        - Static assets
+/scripts/       - Build and setup helpers
+/tests/         - Vitest test suites
+/cms/           - Content pipeline (placeholder)
+```
+
+## Developing
+
+```
+npm install
+npm run dev
+```
+
+The journal section lives under `/app/journal`. For now it contains mocked entries and a placeholder layout. Individual entries are served via `/journal/[slug]`.
+
+Content from `coherenceism.content` will eventually be injected via a CMS pipeline in `/cms`.

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: #ffffff;
+}
+
+body {
+  background-color: var(--background);
+}

--- a/app/journal/[slug]/page.tsx
+++ b/app/journal/[slug]/page.tsx
@@ -1,0 +1,12 @@
+interface JournalEntryPageProps {
+  params: { slug: string }
+}
+
+export default function JournalEntryPage({ params }: JournalEntryPageProps) {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold">{params.slug}</h1>
+      <p className="mt-2">This is a placeholder for the journal entry content.</p>
+    </main>
+  )
+}

--- a/app/journal/page.tsx
+++ b/app/journal/page.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+
+const mockEntries = [
+  { slug: 'entry-one', title: 'Entry One' },
+  { slug: 'entry-two', title: 'Entry Two' },
+]
+
+export default function JournalIndexPage() {
+  return (
+    <main className="p-4 space-y-2">
+      <h1 className="text-2xl font-bold">Journal</h1>
+      <ul className="list-disc list-inside">
+        {mockEntries.map((entry) => (
+          <li key={entry.slug}>
+            <Link href={`/journal/${entry.slug}`}>{entry.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,12 @@
+import './globals.css'
+import type { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-background font-sans antialiased">
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,8 @@
+export default function HomePage() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold">Coherenceism</h1>
+      <p className="mt-2">Welcome to Coherenceism.info.</p>
+    </main>
+  )
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,22 @@
+import { Slot } from '@radix-ui/react-slot'
+import { cn } from '../../lib/utils'
+import type { ButtonHTMLAttributes, DetailedHTMLProps } from 'react'
+
+export interface ButtonProps
+  extends DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
+  asChild?: boolean
+}
+
+export const Button = ({ className, asChild = false, ...props }: ButtonProps) => {
+  const Comp = asChild ? Slot : 'button'
+  return (
+    <Comp
+      className={cn(
+        'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+        'bg-primary text-primary-foreground shadow hover:bg-primary/90 h-10 px-4 py-2',
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: {
-    appDir: true,
-  },
 }
 
 module.exports = nextConfig

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true,
+  },
+}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "eslint-config-next": "14.1.0",
     "vitest": "^1.0.0",
     "@shadcn/ui": "latest",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "@types/react": "latest",
+    "@types/node": "latest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint": "^8.57.0",
     "eslint-config-next": "14.1.0",
     "vitest": "^1.0.0",
-    "@shadcn/ui": "^0.3.0",
+    "@shadcn/ui": "latest",
     "typescript": "^5.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "coherenceism.info",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "clsx": "^1.2.1",
+    "tailwind-merge": "^2.2.1",
+    "@radix-ui/react-slot": "^1.0.2"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.0.0",
+    "postcss": "^8.0.0",
+    "tailwindcss": "^3.3.2",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "14.1.0",
+    "vitest": "^1.0.0",
+    "@shadcn/ui": "^0.3.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'tailwindcss'
+
+export default {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": "."
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Next.js 14 project skeleton
- add TailwindCSS and shadcn/ui components
- scaffold journal routes with placeholders
- provide root layout and globals
- document repository structure and future content flow

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68572051656483269895f0d1f4075cda