### PR TITLE
Add vitest setup and update tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repo hosts the Next.js frontend for **Coherenceism.info**. Content is store
 ```
 npm install
 npm run dev
+npm test
 ```
 
 The journal section lives under `/app/journal`. For now it contains mocked entries and a placeholder layout. Individual entries are served via `/journal/[slug]`.

--- a/TASKS.md
+++ b/TASKS.md
@@ -6,8 +6,8 @@
 
 ## 🔹 PHASE 0: Foundation Setup
 
-- [ ] ✅ Initialize Next.js 14 app with App Router
-- [ ] ✅ Install Tailwind CSS + set up PostCSS config
+- [x] Initialize Next.js 14 app with App Router
+- [x] Install Tailwind CSS + set up PostCSS config
 - [ ] ✅ Install MDX support with `next-mdx-remote` or native MDX routing
 - [ ] ✅ Create `/content` directory and configure local dev to clone/sync with `https://github.com/joshua-lossner/coherenceism.content.git`
 - [ ] ✅ Add `.env.example` and `.env.local` with Git sync options (optional)

--- a/tests/example.test.ts
+++ b/tests/example.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest'
+
+describe('sanity check', () => {
+  it('should pass', () => {
+    expect(true).toBe(true)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
- mark Tailwind setup as completed in TASKS
- add vitest config and a sample test
- document running `npm test` in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586cc09eec83269fc29f13714eb09c