### PR TITLE
Implement content sync setup for Phase 0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# URL of the content repository
+CONTENT_REPO_URL=https://github.com/joshua-lossner/coherenceism.content.git

--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,2 @@
+# Local overrides for content sync
+CONTENT_REPO_URL=https://github.com/joshua-lossner/coherenceism.content.git

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules
 .next
-.env.local
 .env.*.local
 .DS_Store
 out

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repo hosts the Next.js frontend for **Coherenceism.info**. Content is store
 /lib/           - Server/client utilities
 /public/        - Static assets
 /scripts/       - Build and setup helpers
+/content/       - Markdown content cloned from `coherenceism.content`
 /tests/         - Vitest test suites
 /cms/           - Content pipeline (placeholder)
 ```
@@ -20,6 +21,12 @@ This repo hosts the Next.js frontend for **Coherenceism.info**. Content is store
 npm install
 npm run dev
 npm test
+```
+
+To pull down the markdown content repository, run:
+
+```
+npm run content:sync
 ```
 
 MDX pages can be placed anywhere under `app/` using the `.mdx` extension. See `app/hello.mdx` for a simple example.

--- a/TASKS.md
+++ b/TASKS.md
@@ -9,8 +9,8 @@
 - [x] Initialize Next.js 14 app with App Router
 - [x] Install Tailwind CSS + set up PostCSS config
 - [x] Install MDX support with `next-mdx-remote` or native MDX routing
-- [ ] ✅ Create `/content` directory and configure local dev to clone/sync with `https://github.com/joshua-lossner/coherenceism.content.git`
-- [ ] ✅ Add `.env.example` and `.env.local` with Git sync options (optional)
+- [x] Create `/content` directory and configure local dev to clone/sync with `https://github.com/joshua-lossner/coherenceism.content.git`
+- [x] Add `.env.example` and `.env.local` with Git sync options (optional)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest"
+    "test": "vitest",
+    "content:sync": "node scripts/sync-content.js"
   },
   "dependencies": {
     "next": "14.1.0",

--- a/scripts/sync-content.js
+++ b/scripts/sync-content.js
@@ -1,0 +1,18 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const repoUrl = process.env.CONTENT_REPO_URL || 'https://github.com/joshua-lossner/coherenceism.content.git';
+const contentDir = path.resolve(__dirname, '..', 'content');
+
+function run(cmd) {
+  execSync(cmd, { stdio: 'inherit' });
+}
+
+if (!fs.existsSync(contentDir)) {
+  console.log(`Cloning content repo to ${contentDir}...`);
+  run(`git clone ${repoUrl} ${contentDir}`);
+} else {
+  console.log('Updating content repo...');
+  run(`git -C ${contentDir} pull`);
+}


### PR DESCRIPTION
## Summary
- add `/content` folder and script to clone/pull content repo
- expose `CONTENT_REPO_URL` via `.env.example` and `.env.local`
- include new `content:sync` npm script and update README
- mark Foundation Setup tasks complete
- adjust `.gitignore`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685872b4c1fc83268a20c0e25ac43c5e