### PR TITLE
Implement content architecture

### DIFF
--- a/app/books/[slug]/page.tsx
+++ b/app/books/[slug]/page.tsx
@@ -1,0 +1,15 @@
+import { getEntry } from '../../../lib/content'
+
+interface BookPageProps {
+  params: { slug: string }
+}
+
+export default async function BookPage({ params }: BookPageProps) {
+  const { frontmatter, content } = await getEntry('books', params.slug)
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">{frontmatter.title}</h1>
+      {content}
+    </main>
+  )
+}

--- a/app/books/page.tsx
+++ b/app/books/page.tsx
@@ -1,15 +1,15 @@
 import Link from 'next/link'
 import { getAllEntries } from '../../lib/content'
 
-export default async function JournalIndexPage() {
-  const entries = await getAllEntries('journal')
+export default async function BooksIndexPage() {
+  const entries = await getAllEntries('books')
   return (
     <main className="p-4 space-y-2">
-      <h1 className="text-2xl font-bold">Journal</h1>
+      <h1 className="text-2xl font-bold">Books</h1>
       <ul className="list-disc list-inside">
         {entries.map((entry) => (
           <li key={entry.slug}>
-            <Link href={`/journal/${entry.slug}`}>{entry.frontmatter.title}</Link>
+            <Link href={`/books/${entry.slug}`}>{entry.frontmatter.title}</Link>
           </li>
         ))}
       </ul>

--- a/app/journal/[slug]/page.tsx
+++ b/app/journal/[slug]/page.tsx
@@ -1,12 +1,16 @@
+import { getEntry } from '../../../lib/content'
+import type { Frontmatter } from '../../../lib/content'
+
 interface JournalEntryPageProps {
   params: { slug: string }
 }
 
-export default function JournalEntryPage({ params }: JournalEntryPageProps) {
+export default async function JournalEntryPage({ params }: JournalEntryPageProps) {
+  const { frontmatter, content } = await getEntry('journal', params.slug)
   return (
-    <main className="p-4">
-      <h1 className="text-2xl font-bold">{params.slug}</h1>
-      <p className="mt-2">This is a placeholder for the journal entry content.</p>
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">{frontmatter.title}</h1>
+      {content}
     </main>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,14 @@
+import Link from 'next/link'
+
 export default function HomePage() {
   return (
-    <main className="p-4">
+    <main className="p-4 space-y-2">
       <h1 className="text-2xl font-bold">Coherenceism</h1>
       <p className="mt-2">Welcome to Coherenceism.info.</p>
+      <nav className="space-x-4">
+        <Link href="/journal">Journal</Link>
+        <Link href="/books">Books</Link>
+      </nav>
     </main>
   )
 }

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+import { getEntriesByTag } from '../../../lib/content'
+
+interface TagPageProps {
+  params: { tag: string }
+}
+
+export default async function TagPage({ params }: TagPageProps) {
+  const entries = await getEntriesByTag(params.tag)
+  return (
+    <main className="p-4 space-y-2">
+      <h1 className="text-2xl font-bold">Tag: {params.tag}</h1>
+      <ul className="list-disc list-inside">
+        {entries.map((entry) => (
+          <li key={entry.slug}>
+            <Link href={`/${entry.frontmatter.type === 'journal' ? 'journal' : 'books'}/${entry.slug}`}>{entry.frontmatter.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
+}

--- a/content/books/book-one.mdx
+++ b/content/books/book-one.mdx
@@ -1,0 +1,13 @@
+---
+title: Book One
+date: 2024-03-01
+tags:
+  - book
+  - sample
+summary: First book example
+type: book
+---
+
+# Book One
+
+This is a sample book entry.

--- a/content/books/book-two.mdx
+++ b/content/books/book-two.mdx
@@ -1,0 +1,13 @@
+---
+title: Book Two
+date: 2024-04-01
+tags:
+  - book
+  - advanced
+summary: Second book example
+type: book
+---
+
+# Book Two
+
+More about the second book.

--- a/content/journal/entry-one.mdx
+++ b/content/journal/entry-one.mdx
@@ -1,0 +1,13 @@
+---
+title: Entry One
+date: 2024-01-01
+tags:
+  - intro
+  - test
+summary: First journal entry
+type: journal
+---
+
+# Entry One
+
+This is the first sample entry.

--- a/content/journal/entry-two.mdx
+++ b/content/journal/entry-two.mdx
@@ -1,0 +1,13 @@
+---
+title: Entry Two
+date: 2024-02-01
+tags:
+  - second
+  - test
+summary: Second journal entry
+type: journal
+---
+
+# Entry Two
+
+More sample content.

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -1,0 +1,51 @@
+import fs from 'fs/promises'
+import path from 'path'
+import matter from 'gray-matter'
+import { compileMDX } from 'next-mdx-remote/rsc'
+
+export type Frontmatter = {
+  title: string
+  date: string
+  tags: string[]
+  summary: string
+  type: string
+}
+
+const CONTENT_ROOT = path.join(process.cwd(), 'content')
+
+export async function getEntry(type: 'journal' | 'books', slug: string) {
+  const filePath = path.join(CONTENT_ROOT, type, `${slug}.mdx`)
+  const source = await fs.readFile(filePath, 'utf8')
+  const { data, content } = matter(source)
+  const mdx = await compileMDX({ source: content })
+  return { frontmatter: data as Frontmatter, content: mdx }
+}
+
+export async function getAllEntries(type: 'journal' | 'books') {
+  const dir = path.join(CONTENT_ROOT, type)
+  const files = await fs.readdir(dir)
+  const entries = await Promise.all(
+    files
+      .filter((f) => f.endsWith('.mdx'))
+      .map(async (file) => {
+        const raw = await fs.readFile(path.join(dir, file), 'utf8')
+        const { data } = matter(raw)
+        const slug = file.replace(/\.mdx$/, '')
+        return { slug, frontmatter: data as Frontmatter }
+      }),
+  )
+  entries.sort(
+    (a, b) =>
+      new Date(b.frontmatter.date).getTime() -
+      new Date(a.frontmatter.date).getTime(),
+  )
+  return entries
+}
+
+export async function getEntriesByTag(tag: string) {
+  const [journal, books] = await Promise.all([
+    getAllEntries('journal'),
+    getAllEntries('books'),
+  ])
+  return [...journal, ...books].filter((e) => e.frontmatter.tags.includes(tag))
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "react-dom": "18.2.0",
     "clsx": "^1.2.1",
     "tailwind-merge": "^2.2.1",
-    "@radix-ui/react-slot": "^1.0.2"
+    "@radix-ui/react-slot": "^1.0.2",
+    "gray-matter": "^4.0.3",
+    "next-mdx-remote": "^5.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.0.0",


### PR DESCRIPTION
## Summary
- add sample journal and book entries
- parse markdown via `gray-matter` and `next-mdx-remote`
- implement content utilities in `lib/content.ts`
- add journal, books and tag index pages
- render individual entries dynamically
- link to sections from home page

## Testing
- `npm install` *(fails: 403 Forbidden – registry.npmjs.org)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587b90795c8326b6b4214ce01c0464