### PR TITLE
Update content sync docs and Vercel bundle config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ To pull down the markdown content repository, run:
 npm run content:sync
 ```
 
+### Content Sync in Build
+
+`npm run build` triggers `scripts/sync-content.js` via the `prebuild` script. This
+script clones the `coherenceism.content.git` repository into the `content/`
+directory so the markdown is bundled with the site. You can override the
+repository URL with the `CONTENT_REPO_URL` environment variable. On Vercel,
+ensure this variable provides access to the repo (or make the repo public) so the
+build can succeed.
+
 MDX pages can be placed anywhere under `app/` using the `.mdx` extension. See `app/hello.mdx` for a simple example.
 
 The journal section lives under `/app/journal`. For now it contains mocked entries and a placeholder layout. Individual entries are served via `/journal/[slug]`.

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const withMDX = require('@next/mdx')({
   extension: /\.mdx?$/,
 })
@@ -6,6 +7,11 @@ const withMDX = require('@next/mdx')({
 const nextConfig = withMDX({
   reactStrictMode: true,
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
+  experimental: {
+    outputFileTracingIncludes: {
+      './': [path.join(__dirname, 'content')],
+    },
+  },
 })
 
 module.exports = nextConfig


### PR DESCRIPTION
## Summary
- ensure Vercel bundles the `content/` directory for serverless functions
- document content sync during the build step

## Testing
- `npm install`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6859654b7fac8326b6ebbdee4e9f1772