### PR TITLE
Include content dir in Vercel bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ MDX pages can be placed anywhere under `app/` using the `.mdx` extension. See `a
 The journal section lives under `/app/journal`. For now it contains mocked entries and a placeholder layout. Individual entries are served via `/journal/[slug]`.
 
 Content from `coherenceism.content` will eventually be injected via a CMS pipeline in `/cms`.
+
+## Content Sync during Build
+
+`npm run build` automatically executes `scripts/sync-content.js` to clone the `coherenceism.content.git` repository into the `content/` folder. The repository URL can be customized with the `CONTENT_REPO_URL` environment variable. When deploying to Vercel, ensure this variable points to a repo the build process can access, either by using public access or providing appropriate credentials.

--- a/next.config.js
+++ b/next.config.js
@@ -1,11 +1,17 @@
 const withMDX = require('@next/mdx')({
   extension: /\.mdx?$/,
 })
+const path = require('path')
 
 /** @type {import('next').NextConfig} */
 const nextConfig = withMDX({
   reactStrictMode: true,
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
+  experimental: {
+    outputFileTracingIncludes: {
+      './': [path.join(__dirname, 'content')],
+    },
+  },
 })
 
 module.exports = nextConfig


### PR DESCRIPTION
## Summary
- include `content/` in Vercel serverless output via `experimental.outputFileTracingIncludes`
- document build-time content sync and `CONTENT_REPO_URL` setup

## Testing
- `npm install`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68599b4dc7cc8326955eb4bbd0172109