### PR TITLE
Refactor journal menu to display entries on single line

### DIFF
--- a/components/WOPRTerminal.tsx
+++ b/components/WOPRTerminal.tsx
@@ -693,10 +693,7 @@ const WOPRTerminal = () => {
           journals.slice(0, 10).forEach((journal, index) => {
             const title = journal.title
             const date = journal.date ? ` (${journal.date})` : ''
-            addLine(`    ${index + 1}. ${title}`, 'ai-response', false, `${index + 1}`)
-            if (date) {
-              addLine(`       ${date}`, 'ai-response')
-            }
+            addLine(`    ${index + 1}. ${title}${date}`, 'ai-response', false, `${index + 1}`)
           })
           addLine("────────────────────────────────────────", 'separator')
           addLine("    Type the number to read an entry.", 'ai-response')


### PR DESCRIPTION
## Summary
- Refactored the journal menu UI to display each entry on a single line
- Combined journal title and date into format: `1. Interface as Invitation (2025-06-28)`
- Preserved terminal styling and ANSI color codes

## Changes Made
- Modified `WOPRTerminal.tsx` to combine title and date on the same line
- Removed the separate date line that was displayed below each title
- Maintained all existing styling and formatting

## Test plan
- [ ] Navigate to `/journal` command in the terminal
- [ ] Verify journal entries display on single lines with dates in parentheses
- [ ] Confirm clickable functionality still works
- [ ] Check that terminal styling is preserved

🤖 Generated with [Claude Code](https://claude.ai/code)