### PR TITLE
Add Vercel Analytics integration

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import './globals.css'
+import { Analytics } from '@vercel/analytics/next'
 
 export const metadata = {
   title: 'WOPR COHERENCE ARCHIVE v3.7.42',
@@ -12,7 +13,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+        <Analytics />
+      </body>
     </html>
   )
 } 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.7.42",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.16",
+        "@vercel/analytics": "^1.5.0",
         "autoprefixer": "^10.4.16",
         "next": "14.0.0",
         "openai": "^5.8.2",
@@ -1061,6 +1062,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.16",
+    "@vercel/analytics": "^1.5.0",
     "autoprefixer": "^10.4.16",
     "next": "14.0.0",
     "openai": "^5.8.2",


### PR DESCRIPTION
## Summary
- Add Vercel Analytics to track visitor metrics and page views
- Zero-config privacy-compliant analytics solution
- Automatic page view tracking across the entire site

## Changes
- Install @vercel/analytics package
- Add Analytics component to root layout (app/layout.tsx)
- Verified build compiles successfully

## Benefits
- Real-time visitor insights
- Page view analytics
- Performance metrics
- GDPR-compliant (no cookies)
- Zero configuration required

## Test plan
- [ ] Verify application builds and runs correctly
- [ ] Check Analytics component loads without errors
- [ ] Enable Web Analytics in Vercel dashboard after merge
- [ ] Confirm analytics data collection after deployment

## Next steps after merge
1. Enable Web Analytics in Vercel project dashboard
2. Deploy to production
3. Monitor analytics data collection

🤖 Generated with [Claude Code](https://claude.ai/code)