### PR TITLE
Fix Audio Narration Directory Path Bug

### DIFF
--- a/data/audio-cache.json
+++ b/data/audio-cache.json
@@ -128,5 +128,55 @@
     "fileSize": 4785482,
     "chunks": 6,
     "duration": 299.09262500000006
+  },
+  {
+    "contentHash": "57375c66efc8fb5c-chunk-0",
+    "contentType": "journal",
+    "contentId": "2025-06-17-system-book.md-chunk-0",
+    "audioPath": "audio/narrations/journals/57375c66efc8fb5c-chunk-0.mp3",
+    "createdAt": 1751417047621,
+    "fileSize": 1023209,
+    "chunks": 1,
+    "duration": 63.9505625
+  },
+  {
+    "contentHash": "57375c66efc8fb5c-chunk-1",
+    "contentType": "journal",
+    "contentId": "2025-06-17-system-book.md-chunk-1",
+    "audioPath": "audio/narrations/journals/57375c66efc8fb5c-chunk-1.mp3",
+    "createdAt": 1751417047623,
+    "fileSize": 1047032,
+    "chunks": 1,
+    "duration": 65.4395
+  },
+  {
+    "contentHash": "57375c66efc8fb5c-chunk-2",
+    "contentType": "journal",
+    "contentId": "2025-06-17-system-book.md-chunk-2",
+    "audioPath": "audio/narrations/journals/57375c66efc8fb5c-chunk-2.mp3",
+    "createdAt": 1751417047624,
+    "fileSize": 1000639,
+    "chunks": 1,
+    "duration": 62.5399375
+  },
+  {
+    "contentHash": "57375c66efc8fb5c-chunk-3",
+    "contentType": "journal",
+    "contentId": "2025-06-17-system-book.md-chunk-3",
+    "audioPath": "audio/narrations/journals/57375c66efc8fb5c-chunk-3.mp3",
+    "createdAt": 1751417047625,
+    "fileSize": 926660,
+    "chunks": 1,
+    "duration": 57.91625
+  },
+  {
+    "contentHash": "57375c66efc8fb5c",
+    "contentType": "journal",
+    "contentId": "2025-06-17-system-book.md",
+    "audioPath": "audio/narrations/journals/57375c66efc8fb5c-chunk-0.mp3",
+    "createdAt": 1751417047625,
+    "fileSize": 3997540,
+    "chunks": 4,
+    "duration": 249.84625
   }
 ]

--- a/lib/audio-cache.ts
+++ b/lib/audio-cache.ts
@@ -22,8 +22,8 @@ export class AudioCacheManager {
     const dirs = [
       this.CACHE_DIR,
       path.join(this.CACHE_DIR, 'journals'),
-      path.join(this.CACHE_DIR, 'books'),
       path.join(this.CACHE_DIR, 'chapters'),
+      path.join(this.CACHE_DIR, 'about'),
       path.dirname(this.METADATA_FILE)
     ];
     
@@ -91,7 +91,9 @@ export class AudioCacheManager {
     this.ensureDirectories();
     
     const filename = `${contentHash}.mp3`;
-    const relativePath = `audio/narrations/${contentType}s/${filename}`;
+    const dirName = contentType === 'journal' ? 'journals' : 
+                   contentType === 'chapter' ? 'chapters' : 'about';
+    const relativePath = `audio/narrations/${dirName}/${filename}`;
     const fullPath = path.join(process.cwd(), 'public', relativePath);
     
     // Write audio file


### PR DESCRIPTION
## Summary
- Fixes 500 error in audio narration API caused by incorrect directory path construction
- Resolves issue where 'about' content type was incorrectly pluralized to 'abouts'
- Ensures proper directory mapping: journal→journals, chapter→chapters, about→about
- Includes updated audio cache metadata from successful local testing

## Test plan
- [x] Verified narration works locally after fix
- [x] Confirmed directory paths are created correctly
- [x] Tested with multiple content types
- [ ] Test in staging environment

🤖 Generated with [Claude Code](https://claude.ai/code)