### PR TITLE
Implement changelog system with dynamic version display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WOPR COHERENCE ARCHIVE v3.7.42
+# WOPR COHERENCE ARCHIVE
 
 A WarGames-inspired terminal interface for exploring Coherenceism philosophy, powered by OpenAI's GPT-4.
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ When viewing journal entries or book chapters:
 | `OPENAI_API_KEY` | Your OpenAI API key for GPT-4 access | Yes |
 | `ELEVENLABS_API_KEY` | Your ElevenLabs API key for audio narration | Yes |
 | `BLOB_READ_WRITE_TOKEN` | Your Vercel Blob token for audio file storage | Yes |
+| `GITHUB_TOKEN` | GitHub personal access token for changelog (increases API rate limit) | No |
 
 ## 🎧 Audio Narration System
 

--- a/app/api/changelog/route.ts
+++ b/app/api/changelog/route.ts
@@ -48,7 +48,7 @@ export async function GET(request: NextRequest) {
     console.log('Fetching from GitHub API...')
     // Fetch merged PRs from GitHub
     const response = await fetch(
-      'https://api.github.com/repos/joshua-lossner/coherenceism.info/pulls?state=closed&sort=updated&direction=desc&per_page=50',
+      'https://api.github.com/repos/joshua-lossner/coherenceism.info/pulls?state=closed&per_page=100',
       {
         headers: {
           'Accept': 'application/vnd.github.v3+json',
@@ -103,6 +103,13 @@ export async function GET(request: NextRequest) {
         description: description.substring(0, 150) + (description.length > 150 ? '...' : ''),
         fullDescription: pr.body || 'No description available.'
       }
+    })
+
+    // Sort by merge date descending (most recent first)
+    changelog.sort((a, b) => {
+      const dateA = new Date(a.date).getTime()
+      const dateB = new Date(b.date).getTime()
+      return dateB - dateA
     })
 
     console.log('Generated changelog entries:', changelog.length)

--- a/app/api/changelog/route.ts
+++ b/app/api/changelog/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+interface GitHubPR {
+  number: number
+  title: string
+  body: string
+  merged_at: string
+  merge_commit_sha: string
+  base: {
+    ref: string
+  }
+  head: {
+    ref: string
+  }
+}
+
+interface ChangelogEntry {
+  version: string
+  date: string
+  prNumber: number
+  title: string
+  description: string
+  fullDescription: string
+}
+
+// Cache for changelog data
+let changelogCache: ChangelogEntry[] | null = null
+let cacheTimestamp = 0
+const CACHE_DURATION = 5 * 60 * 1000 // 5 minutes
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const prNumber = searchParams.get('pr')
+    
+    // Check cache first
+    const now = Date.now()
+    if (changelogCache && (now - cacheTimestamp) < CACHE_DURATION) {
+      if (prNumber) {
+        const entry = changelogCache.find(e => e.prNumber === parseInt(prNumber))
+        return NextResponse.json(entry || { error: 'Release not found' })
+      }
+      return NextResponse.json(changelogCache)
+    }
+
+    // Fetch merged PRs from GitHub
+    const response = await fetch(
+      'https://api.github.com/repos/joshua-lossner/coherenceism.info/pulls?state=closed&sort=updated&direction=desc&per_page=50',
+      {
+        headers: {
+          'Accept': 'application/vnd.github.v3+json',
+          'User-Agent': 'coherenceism-changelog',
+          // Note: GitHub API works without auth for public repos, but rate limits apply
+        },
+      }
+    )
+
+    if (!response.ok) {
+      throw new Error(`GitHub API error: ${response.status}`)
+    }
+
+    const prs: GitHubPR[] = await response.json()
+    
+    // Filter merged PRs and convert to changelog entries
+    const mergedPrs = prs.filter(pr => pr.merged_at !== null)
+    
+    const changelog: ChangelogEntry[] = mergedPrs.map(pr => {
+      const mergeDate = new Date(pr.merged_at)
+      const dateStr = mergeDate.toISOString().split('T')[0] // YYYY-MM-DD format
+      const version = `${dateStr}.${pr.number}`
+      
+      // Extract first paragraph or summary for description
+      const description = pr.body 
+        ? pr.body.split('\n\n')[0].replace(/^#+\s*/, '').trim()
+        : pr.title
+      
+      return {
+        version,
+        date: dateStr,
+        prNumber: pr.number,
+        title: pr.title,
+        description: description.substring(0, 150) + (description.length > 150 ? '...' : ''),
+        fullDescription: pr.body || 'No description available.'
+      }
+    })
+
+    // Update cache
+    changelogCache = changelog
+    cacheTimestamp = now
+
+    // Return specific PR if requested
+    if (prNumber) {
+      const entry = changelog.find(e => e.prNumber === parseInt(prNumber))
+      return NextResponse.json(entry || { error: 'Release not found' })
+    }
+
+    // Return all changelog entries
+    return NextResponse.json(changelog)
+
+  } catch (error) {
+    console.error('Changelog API error:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch changelog data' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/changelog/route.ts
+++ b/app/api/changelog/route.ts
@@ -69,9 +69,12 @@ export async function GET(request: NextRequest) {
     const prs: GitHubPR[] = await response.json()
     console.log('Total PRs fetched:', prs.length)
     
-    // Filter merged PRs and convert to changelog entries
-    const mergedPrs = prs.filter(pr => pr.merged_at !== null)
-    console.log('Merged PRs found:', mergedPrs.length)
+    // Filter merged PRs to main branch only
+    const mergedPrs = prs.filter(pr => 
+      pr.merged_at !== null && 
+      pr.base.ref === 'main'
+    )
+    console.log('Merged PRs to main found:', mergedPrs.length)
     
     if (mergedPrs.length === 0) {
       console.log('No merged PRs found. Sample PRs:', prs.slice(0, 3).map(pr => ({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import './globals.css'
 import { Analytics } from '@vercel/analytics/next'
 
 export const metadata = {
-  title: 'WOPR COHERENCE ARCHIVE v3.7.42',
+  title: 'WOPR COHERENCE ARCHIVE',
   description: 'Neural Terminal Interface - Coherenceism Archive System',
   robots: {
     index: false,

--- a/components/WOPRTerminal.tsx
+++ b/components/WOPRTerminal.tsx
@@ -1082,9 +1082,9 @@ As we stand at the brink of remarkable transformations in artificial intelligenc
           pageEntries.forEach((release, index) => {
             const displayNumber = index + 1
             addLine(`${displayNumber}. ${release.title}`, 'normal', false, `${displayNumber}`)
-            addLine(`   ${release.description}`, 'ai-response')
-            addLine("")
           })
+          
+          addLine("")
           
           // Pagination info and controls
           if (totalPages > 1) {

--- a/components/WOPRTerminal.tsx
+++ b/components/WOPRTerminal.tsx
@@ -1068,13 +1068,7 @@ As we stand at the brink of remarkable transformations in artificial intelligenc
         } else {
           // Display up to 10 most recent releases
           changelogData.slice(0, 10).forEach((release, index) => {
-            // Condense the title by truncating if too long
-            const maxTitleLength = 50
-            const condensedTitle = release.title.length > maxTitleLength 
-              ? release.title.substring(0, maxTitleLength) + '...'
-              : release.title
-            
-            addLine(`${index + 1}. v${release.version} - ${condensedTitle}`, 'normal', false, `${index + 1}`)
+            addLine(`${index + 1}. ${release.title}`, 'normal', false, `${index + 1}`)
             addLine(`   ${release.description}`, 'ai-response')
             addLine("")
           })

--- a/components/WOPRTerminal.tsx
+++ b/components/WOPRTerminal.tsx
@@ -1020,20 +1020,31 @@ As we stand at the brink of remarkable transformations in artificial intelligenc
         if (!changelogLoaded) {
           setIsProcessing(true)
           try {
+            console.log('Fetching changelog from API...')
             const response = await fetch('/api/changelog')
             const changelogData = await response.json()
+            
+            console.log('Changelog response:', { 
+              ok: response.ok, 
+              status: response.status,
+              isArray: Array.isArray(changelogData),
+              dataLength: Array.isArray(changelogData) ? changelogData.length : 'not array',
+              data: changelogData
+            })
             
             if (response.ok && Array.isArray(changelogData)) {
               setChangelog(changelogData)
               setChangelogLoaded(true)
+              console.log('Changelog loaded successfully:', changelogData.length, 'entries')
             } else {
-              await typeResponse(`Failed to load changelog. Please try again later.`, false)
+              console.error('Changelog API error:', changelogData)
+              await typeResponse(`Failed to load changelog: ${changelogData.error || 'Unknown error'}`, false)
               setIsProcessing(false)
               break
             }
           } catch (error) {
             console.error('Changelog fetch error:', error)
-            await typeResponse(`Connection error. Unable to fetch changelog data.`, false)
+            await typeResponse(`Connection error: ${error instanceof Error ? error.message : 'Unknown error'}`, false)
             setIsProcessing(false)
             break
           }
@@ -1046,18 +1057,27 @@ As we stand at the brink of remarkable transformations in artificial intelligenc
         addLine("Recent releases and updates to the WOPR Coherence Archive:", 'normal')
         addLine("")
         
-        // Display up to 10 most recent releases
-        changelog.slice(0, 10).forEach((release, index) => {
-          addLine(`${index + 1}. v${release.version} - ${release.title}`, 'normal', false, `${index + 1}`)
-          addLine(`   ${release.description}`, 'ai-response')
+        if (changelog.length === 0) {
+          addLine("No releases found. This could be due to:", 'ai-response')
+          addLine("• No merged pull requests in the repository", 'ai-response')
+          addLine("• GitHub API rate limiting", 'ai-response')
+          addLine("• Connection issues", 'ai-response')
           addLine("")
-        })
+        } else {
+          // Display up to 10 most recent releases
+          changelog.slice(0, 10).forEach((release, index) => {
+            addLine(`${index + 1}. v${release.version} - ${release.title}`, 'normal', false, `${index + 1}`)
+            addLine(`   ${release.description}`, 'ai-response')
+            addLine("")
+          })
+          
+          addLine("Select a number to view detailed release notes.")
+          addLine("")
+        }
         
         addLine("x. back to help", 'separator', false, 'x')
         addLine("")
         addLine(createBorder(), 'normal')
-        addLine("")
-        addLine("Select a number to view detailed release notes.")
         addLine("")
         break
 

--- a/components/WOPRTerminal.tsx
+++ b/components/WOPRTerminal.tsx
@@ -1555,8 +1555,50 @@ ${release.fullDescription}`
           const entriesPerPage = 5
           const totalPages = Math.ceil(changelog.length / entriesPerPage)
           if (changelogPage < totalPages) {
-            setChangelogPage(changelogPage + 1)
-            processCommand('/changelog')
+            const nextPage = changelogPage + 1
+            setChangelogPage(nextPage)
+            
+            // Manually refresh the display without re-fetching
+            setTerminalLines([])
+            await new Promise(resolve => setTimeout(resolve, 100))
+            
+            // Redisplay changelog with new page
+            addLine(createBorder('RELEASE NOTES & VERSION HISTORY'), 'normal')
+            addLine("")
+            addLine("Recent releases and updates to the WOPR Coherence Archive:", 'normal')
+            addLine("")
+            
+            const startIndex = (nextPage - 1) * entriesPerPage
+            const endIndex = startIndex + entriesPerPage
+            const pageEntries = changelog.slice(startIndex, endIndex)
+            
+            pageEntries.forEach((release, index) => {
+              const displayNumber = index + 1
+              addLine(`${displayNumber}. ${release.title}`, 'normal', false, `${displayNumber}`)
+            })
+            
+            addLine("")
+            
+            if (totalPages > 1) {
+              addLine(createBorder('', '─'), 'separator')
+              addLine(`Page ${nextPage} of ${totalPages} • ${changelog.length} total releases`, 'ai-response')
+              addLine("")
+              
+              if (nextPage < totalPages) {
+                addLine("n. next page", 'separator', false, 'n')
+              }
+              if (nextPage > 1) {
+                addLine("p. previous page", 'separator', false, 'p')
+              }
+              addLine("")
+            }
+            
+            addLine("Select a number to view detailed release notes.")
+            addLine("")
+            addLine("x. back to help", 'separator', false, 'x')
+            addLine("")
+            addLine(createBorder(), 'normal')
+            addLine("")
           } else {
             await typeResponse(`Already on the last page.`, false)
           }
@@ -1580,9 +1622,53 @@ ${release.fullDescription}`
       case '/PAUSE':
         if (currentMenu === 'changelog' && !isViewingContent) {
           // Handle previous page in changelog
+          const entriesPerPage = 5
+          const totalPages = Math.ceil(changelog.length / entriesPerPage)
           if (changelogPage > 1) {
-            setChangelogPage(changelogPage - 1)
-            processCommand('/changelog')
+            const prevPage = changelogPage - 1
+            setChangelogPage(prevPage)
+            
+            // Manually refresh the display without re-fetching
+            setTerminalLines([])
+            await new Promise(resolve => setTimeout(resolve, 100))
+            
+            // Redisplay changelog with new page
+            addLine(createBorder('RELEASE NOTES & VERSION HISTORY'), 'normal')
+            addLine("")
+            addLine("Recent releases and updates to the WOPR Coherence Archive:", 'normal')
+            addLine("")
+            
+            const startIndex = (prevPage - 1) * entriesPerPage
+            const endIndex = startIndex + entriesPerPage
+            const pageEntries = changelog.slice(startIndex, endIndex)
+            
+            pageEntries.forEach((release, index) => {
+              const displayNumber = index + 1
+              addLine(`${displayNumber}. ${release.title}`, 'normal', false, `${displayNumber}`)
+            })
+            
+            addLine("")
+            
+            if (totalPages > 1) {
+              addLine(createBorder('', '─'), 'separator')
+              addLine(`Page ${prevPage} of ${totalPages} • ${changelog.length} total releases`, 'ai-response')
+              addLine("")
+              
+              if (prevPage < totalPages) {
+                addLine("n. next page", 'separator', false, 'n')
+              }
+              if (prevPage > 1) {
+                addLine("p. previous page", 'separator', false, 'p')
+              }
+              addLine("")
+            }
+            
+            addLine("Select a number to view detailed release notes.")
+            addLine("")
+            addLine("x. back to help", 'separator', false, 'x')
+            addLine("")
+            addLine(createBorder(), 'normal')
+            addLine("")
           } else {
             await typeResponse(`Already on the first page.`, false)
           }

--- a/components/WOPRTerminal.tsx
+++ b/components/WOPRTerminal.tsx
@@ -2199,7 +2199,7 @@ ${release.fullDescription}`
 
       {/* Status bar */}
       <div className="absolute bottom-0 left-0 right-0 bg-terminal-green text-black p-1 flex justify-between text-sm z-50">
-        <span className="hidden md:block">DIGITAL CONSCIOUSNESS v3.7.42</span>
+        <span className="hidden md:block">DIGITAL CONSCIOUSNESS {changelog[0]?.version ? `v${changelog[0].version}` : 'v3.7.42'}</span>
         <span className="md:block flex-1 text-center md:text-left md:flex-initial">
           COHERENCEISM.INFO {hasConversationContext && <span className="ml-2">• MEMORY: ACTIVE</span>}
         </span>

--- a/components/WOPRTerminal.tsx
+++ b/components/WOPRTerminal.tsx
@@ -1330,6 +1330,28 @@ ${release.fullDescription}`
             playBackgroundMusic(track.sunoUrl)
             await typeResponse(`♪ Opening: ${track.title} playlist in new tab...`, false)
           }
+        } else if (currentMenu === 'changelog') {
+          // Show detailed release notes for selected entry
+          const entriesPerPage = 5
+          const pageOffset = (changelogPage - 1) * entriesPerPage
+          const actualIndex = pageOffset + entryIndex
+          
+          if (changelog.length > actualIndex && actualIndex >= pageOffset && entryIndex < entriesPerPage) {
+            const release = changelog[actualIndex]
+            setTerminalLines([])
+            await new Promise(resolve => setTimeout(resolve, 100))
+            
+            const releaseNotes = `# v${release.version} - ${release.title}
+
+**Release Date:** ${release.date}  
+**Pull Request:** #${release.prNumber}
+
+${release.fullDescription}`
+            
+            addMarkdownContent(releaseNotes, `Release Notes: v${release.version}`, undefined, 'release', `v${release.version}`)
+          } else {
+            await typeResponse(`Release notes not available.`, false)
+          }
         }
         }
         break
@@ -1378,6 +1400,28 @@ ${release.fullDescription}`
               const track = musicTracks[entryIndex]
               playBackgroundMusic(track.sunoUrl)
               await typeResponse(`♪ Opening: ${track.title} playlist in new tab...`, false)
+            }
+          } else if (currentMenu === 'changelog') {
+            // Show detailed release notes for selected entry
+            const entriesPerPage = 5
+            const pageOffset = (changelogPage - 1) * entriesPerPage
+            const actualIndex = pageOffset + entryIndex
+            
+            if (changelog.length > actualIndex && actualIndex >= pageOffset && entryIndex < entriesPerPage) {
+              const release = changelog[actualIndex]
+              setTerminalLines([])
+              await new Promise(resolve => setTimeout(resolve, 100))
+              
+              const releaseNotes = `# v${release.version} - ${release.title}
+
+**Release Date:** ${release.date}  
+**Pull Request:** #${release.prNumber}
+
+${release.fullDescription}`
+              
+              addMarkdownContent(releaseNotes, `Release Notes: v${release.version}`, undefined, 'release', `v${release.version}`)
+            } else {
+              await typeResponse(`Release notes not available.`, false)
             }
           }
         }

--- a/components/WOPRTerminal.tsx
+++ b/components/WOPRTerminal.tsx
@@ -1081,7 +1081,7 @@ As we stand at the brink of remarkable transformations in artificial intelligenc
           // Display current page of releases
           pageEntries.forEach((release, index) => {
             const displayNumber = index + 1
-            addLine(`${displayNumber}. ${release.title}`, 'normal', false, `${displayNumber}`)
+            addLine(`${displayNumber}. ${release.version} : ${release.title}`, 'normal', false, `${displayNumber}`)
           })
           
           addLine("")
@@ -1574,7 +1574,7 @@ ${release.fullDescription}`
             
             pageEntries.forEach((release, index) => {
               const displayNumber = index + 1
-              addLine(`${displayNumber}. ${release.title}`, 'normal', false, `${displayNumber}`)
+              addLine(`${displayNumber}. ${release.version} : ${release.title}`, 'normal', false, `${displayNumber}`)
             })
             
             addLine("")
@@ -1644,7 +1644,7 @@ ${release.fullDescription}`
             
             pageEntries.forEach((release, index) => {
               const displayNumber = index + 1
-              addLine(`${displayNumber}. ${release.title}`, 'normal', false, `${displayNumber}`)
+              addLine(`${displayNumber}. ${release.version} : ${release.title}`, 'normal', false, `${displayNumber}`)
             })
             
             addLine("")

--- a/components/WOPRTerminal.tsx
+++ b/components/WOPRTerminal.tsx
@@ -1044,8 +1044,14 @@ As we stand at the brink of remarkable transformations in artificial intelligenc
               console.log('Changelog loaded successfully:', changelogData.length, 'entries')
             } else {
               console.error('Changelog API error:', changelogData)
-              const errorMessage = (changelogData as any)?.error || 'Unknown error'
-              await typeResponse(`Failed to load changelog: ${errorMessage}`, false)
+              const errorData = changelogData as any
+              
+              if (errorData?.rateLimited) {
+                await typeResponse(`GitHub API rate limit exceeded. The changelog uses GitHub's API which has a limit of 60 requests per hour for unauthenticated users. Please try again in about an hour.`, false)
+              } else {
+                const errorMessage = errorData?.error || 'Unknown error'
+                await typeResponse(`Failed to load changelog: ${errorMessage}`, false)
+              }
               setIsProcessing(false)
               break
             }

--- a/components/WOPRTerminal.tsx
+++ b/components/WOPRTerminal.tsx
@@ -1017,12 +1017,13 @@ As we stand at the brink of remarkable transformations in artificial intelligenc
         changeMenu('changelog')
         
         // Fetch changelog data if not loaded
+        let changelogData = changelog
         if (!changelogLoaded) {
           setIsProcessing(true)
           try {
             console.log('Fetching changelog from API...')
             const response = await fetch('/api/changelog')
-            const changelogData = await response.json()
+            changelogData = await response.json()
             
             console.log('Changelog response:', { 
               ok: response.ok, 
@@ -1051,13 +1052,13 @@ As we stand at the brink of remarkable transformations in artificial intelligenc
           setIsProcessing(false)
         }
         
-        // Display changelog
+        // Display changelog - use the fresh data, not the state variable
         addLine(createBorder('RELEASE NOTES & VERSION HISTORY'), 'normal')
         addLine("")
         addLine("Recent releases and updates to the WOPR Coherence Archive:", 'normal')
         addLine("")
         
-        if (changelog.length === 0) {
+        if (!Array.isArray(changelogData) || changelogData.length === 0) {
           addLine("No releases found. This could be due to:", 'ai-response')
           addLine("• No merged pull requests in the repository", 'ai-response')
           addLine("• GitHub API rate limiting", 'ai-response')
@@ -1065,7 +1066,7 @@ As we stand at the brink of remarkable transformations in artificial intelligenc
           addLine("")
         } else {
           // Display up to 10 most recent releases
-          changelog.slice(0, 10).forEach((release, index) => {
+          changelogData.slice(0, 10).forEach((release, index) => {
             addLine(`${index + 1}. v${release.version} - ${release.title}`, 'normal', false, `${index + 1}`)
             addLine(`   ${release.description}`, 'ai-response')
             addLine("")

--- a/components/WOPRTerminal.tsx
+++ b/components/WOPRTerminal.tsx
@@ -1068,7 +1068,13 @@ As we stand at the brink of remarkable transformations in artificial intelligenc
         } else {
           // Display up to 10 most recent releases
           changelogData.slice(0, 10).forEach((release, index) => {
-            addLine(`${index + 1}. v${release.version} - ${release.title}`, 'normal', false, `${index + 1}`)
+            // Condense the title by truncating if too long
+            const maxTitleLength = 50
+            const condensedTitle = release.title.length > maxTitleLength 
+              ? release.title.substring(0, maxTitleLength) + '...'
+              : release.title
+            
+            addLine(`${index + 1}. v${release.version} - ${condensedTitle}`, 'normal', false, `${index + 1}`)
             addLine(`   ${release.description}`, 'ai-response')
             addLine("")
           })
@@ -1570,6 +1576,9 @@ ${release.fullDescription}`
           } else if (currentMenu === 'about') {
             // Go back to main menu from about
             processCommand('/menu')
+          } else if (currentMenu === 'changelog') {
+            // Go back to changelog list from release detail
+            processCommand('/changelog')
           }
         } else {
           // If in a menu listing

--- a/components/WOPRTerminal.tsx
+++ b/components/WOPRTerminal.tsx
@@ -1039,7 +1039,8 @@ As we stand at the brink of remarkable transformations in artificial intelligenc
               console.log('Changelog loaded successfully:', changelogData.length, 'entries')
             } else {
               console.error('Changelog API error:', changelogData)
-              await typeResponse(`Failed to load changelog: ${changelogData.error || 'Unknown error'}`, false)
+              const errorMessage = (changelogData as any)?.error || 'Unknown error'
+              await typeResponse(`Failed to load changelog: ${errorMessage}`, false)
               setIsProcessing(false)
               break
             }


### PR DESCRIPTION
## Summary

• **Comprehensive changelog system** - Added `/changelog` command to view release notes from GitHub PRs
• **Dynamic version display** - Footer now shows current version from latest merged PR (yyyy-mm-dd.pr# format)
• **GitHub API integration** - Fetches merged PRs to main branch with optional authentication for higher rate limits
• **Pagination and filtering** - Shows 5 entries per page, filters to main branch PRs only
• **Improved navigation** - Added 'x' key support across all pages for consistent back navigation

## Features Added

- **Changelog API endpoint** (`/api/changelog/route.ts`) - Fetches and caches GitHub PR data
- **Release notes display** - Full markdown rendering of PR descriptions
- **Version numbering scheme** - Uses merge date + PR number (e.g., 2025-07-02.41)
- **Rate limit handling** - Supports optional GITHUB_TOKEN for higher API limits
- **Dynamic footer versioning** - Replaces static v3.7.42 with latest PR version

## Test Plan

- [ ] Navigate to `/changelog` command and verify release history displays
- [ ] Test pagination with 'n' (next) and 'p' (previous) commands
- [ ] Select numbered entries to view detailed release notes
- [ ] Verify 'x' key navigation works on all pages
- [ ] Check footer displays dynamic version number
- [ ] Test with and without GITHUB_TOKEN environment variable

🤖 Generated with [Claude Code](https://claude.ai/code)