### PR TITLE
Fix footer version loading state

### DIFF
--- a/components/WOPRTerminal.tsx
+++ b/components/WOPRTerminal.tsx
@@ -317,6 +317,28 @@ const WOPRTerminal = () => {
     }
   }, [booksLoaded])
 
+  // Fetch changelog data on component mount for footer version
+  useEffect(() => {
+    const fetchChangelogForVersion = async () => {
+      if (!changelogLoaded) {
+        try {
+          const response = await fetch('/api/changelog')
+          if (response.ok) {
+            const changelogData = await response.json()
+            if (Array.isArray(changelogData) && changelogData.length > 0) {
+              setChangelog(changelogData)
+              setChangelogLoaded(true)
+            }
+          }
+        } catch (error) {
+          console.error('Error fetching changelog for version:', error)
+        }
+      }
+    }
+    
+    fetchChangelogForVersion()
+  }, [changelogLoaded])
+
   // Client-side hydration and mobile detection
   useEffect(() => {
     // Mark as client-side and check mobile

--- a/components/WOPRTerminal.tsx
+++ b/components/WOPRTerminal.tsx
@@ -2221,7 +2221,7 @@ ${release.fullDescription}`
 
       {/* Status bar */}
       <div className="absolute bottom-0 left-0 right-0 bg-terminal-green text-black p-1 flex justify-between text-sm z-50">
-        <span className="hidden md:block">DIGITAL CONSCIOUSNESS {changelog[0]?.version ? `v${changelog[0].version}` : 'v3.7.42'}</span>
+        <span className="hidden md:block">DIGITAL CONSCIOUSNESS {changelog[0]?.version ? `v${changelog[0].version}` : 'LOADING...'}</span>
         <span className="md:block flex-1 text-center md:text-left md:flex-initial">
           COHERENCEISM.INFO {hasConversationContext && <span className="ml-2">• MEMORY: ACTIVE</span>}
         </span>


### PR DESCRIPTION
## Summary

• **Fix loading state** - Replace fake v3.7.42 with 'LOADING...' during initial version fetch
• **Honest feedback** - Shows actual loading state instead of incorrect version number
• **Improved UX** - Users see loading indication rather than misleading static version

## Problem

The footer was briefly showing a fake static version (v3.7.42) during the initial page load while the real version was being fetched from the GitHub API. This could confuse users about the actual current version.

## Solution

- Replace fallback static version with 'LOADING...' text
- Add useEffect to fetch changelog data on component mount
- Provides clear loading state until real version loads

## Test Plan

- [ ] Load the site and verify footer shows 'LOADING...' briefly
- [ ] Confirm footer updates to show actual version (yyyy-mm-dd.pr#) after fetch
- [ ] Verify no fake version numbers are displayed

🤖 Generated with [Claude Code](https://claude.ai/code)