### PR TITLE
Fix M and H keyboard shortcuts for universal navigation

### DIFF
--- a/components/WOPRTerminal.tsx
+++ b/components/WOPRTerminal.tsx
@@ -826,6 +826,7 @@ const WOPRTerminal = () => {
     // Process command without echoing it to terminal
 
     switch (cmd) {
+      case 'M':
       case 'MENU':
       case '/MENU':
         stopNarration() // Stop narration immediately
@@ -861,6 +862,7 @@ const WOPRTerminal = () => {
         addLine("")
         break
 
+      case 'H':
       case 'HELP':
       case '/HELP':
         setTerminalLines([])


### PR DESCRIPTION
## Summary

• **Fix keyboard shortcuts** - M and H keys now work on all terminal screens
• **Universal navigation** - Matches button functionality with keyboard shortcuts
• **Improved UX** - Quick escape routes from any screen using single keypress

## Bug Fix

**Problem:** Users reported that the M and H keyboard shortcuts (shown as underlined in the MENU and HELP buttons) were not working on all terminal screens.

**Solution:** 
- Added `case 'M':` to the existing MENU command handler
- Added `case 'H':` to the existing HELP command handler

## Functionality

**Before:** Only `/menu` and `/help` commands worked
**After:** Single letter shortcuts work everywhere:
- **M** or **m** → Instantly goes to main menu from any screen
- **H** or **h** → Instantly goes to help from any screen

## Test Plan

- [ ] Test M key from Journal screen → should go to main menu
- [ ] Test H key from Books screen → should go to help
- [ ] Test M key from Music screen → should go to main menu  
- [ ] Test H key from About screen → should go to help
- [ ] Test M key from Changelog screen → should go to main menu
- [ ] Test shortcuts work both uppercase and lowercase
- [ ] Verify existing /menu and /help commands still work

🤖 Generated with [Claude Code](https://claude.ai/code)