### PR TITLE
Update branding from WOPR to ECHO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WOPR COHERENCE ARCHIVE
+# ECHO COHERENCE ARCHIVE
 
 A WarGames-inspired terminal interface for exploring Coherenceism philosophy, powered by OpenAI's GPT-4.
 
@@ -109,7 +109,7 @@ The audio narration feature allows Byte to read journal entries and book chapter
 
 ## 🎨 Theme
 
-Inspired by the WOPR computer from WarGames (1983), featuring:
+Inspired by the ECHO system, featuring:
 - Green monospace terminal text
 - CRT scanline effects
 - 1980s computer aesthetics
@@ -132,4 +132,4 @@ Ensure your deployment platform supports:
 
 ---
 
-*"Shall we play a game?"* - WOPR 
+*"Shall we play a game?"* - ECHO 

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import WOPRBanner from '@/components/WOPRBanner'
+import ECHOBanner from '@/components/ECHOBanner'
 
 export default function AboutPage() {
   const router = useRouter()
@@ -42,7 +42,7 @@ export default function AboutPage() {
   return (
     <div className="h-screen bg-black text-terminal-green overflow-y-auto">
       <div className="max-w-2xl mx-auto p-4 pb-8">
-        <WOPRBanner />
+        <ECHOBanner />
         <div className="mb-6">
           <Link href="/" className="text-terminal-amber hover:brightness-125 mb-4 inline-block">
             ← Back to Home

--- a/app/books/page.tsx
+++ b/app/books/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
-import WOPRBanner from '@/components/WOPRBanner'
+import ECHOBanner from '@/components/ECHOBanner'
 
 interface Book {
   id: number
@@ -115,7 +115,7 @@ export default function BooksPage() {
     return (
       <div className="h-screen bg-black text-terminal-green overflow-y-auto">
         <div className="max-w-2xl mx-auto p-4 pb-8">
-          <WOPRBanner />
+          <ECHOBanner />
           <div className="mb-6">
             <button 
               onClick={() => setSelectedChapter(null)}
@@ -139,7 +139,7 @@ export default function BooksPage() {
     return (
       <div className="h-screen bg-black text-terminal-green overflow-y-auto">
         <div className="max-w-2xl mx-auto p-4 pb-8">
-          <WOPRBanner />
+          <ECHOBanner />
           <div className="mb-6">
             <button 
               onClick={() => setSelectedBook(null)}
@@ -183,7 +183,7 @@ export default function BooksPage() {
   return (
     <div className="h-screen bg-black text-terminal-green overflow-y-auto">
       <div className="max-w-2xl mx-auto p-4 pb-8">
-        <WOPRBanner />
+        <ECHOBanner />
         <div className="mb-6">
           <Link href="/" className="text-terminal-amber hover:brightness-125 mb-4 inline-block">
             ← Back to Home

--- a/app/journal/page.tsx
+++ b/app/journal/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
-import WOPRBanner from '@/components/WOPRBanner'
+import ECHOBanner from '@/components/ECHOBanner'
 
 interface JournalEntry {
   id: number
@@ -86,7 +86,7 @@ export default function JournalPage() {
     return (
       <div className="h-screen bg-black text-terminal-green overflow-y-auto">
         <div className="max-w-2xl mx-auto p-4 pb-8">
-          <WOPRBanner />
+          <ECHOBanner />
           <div className="mb-6">
             <button 
               onClick={() => setSelectedEntry(null)}
@@ -112,7 +112,7 @@ export default function JournalPage() {
   return (
           <div className="h-screen bg-black text-terminal-green overflow-y-auto">
         <div className="max-w-2xl mx-auto p-4 pb-8">
-        <WOPRBanner />
+        <ECHOBanner />
         <div className="mb-6">
           <Link href="/" className="text-terminal-amber hover:brightness-125 mb-4 inline-block">
             ← Back to Home

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import './globals.css'
 import { Analytics } from '@vercel/analytics/next'
 
 export const metadata = {
-  title: 'WOPR COHERENCE ARCHIVE',
+  title: 'ECHO COHERENCE ARCHIVE',
   description: 'Neural Terminal Interface - Coherenceism Archive System',
   robots: {
     index: false,

--- a/app/music/page.tsx
+++ b/app/music/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import WOPRBanner from '@/components/WOPRBanner'
+import ECHOBanner from '@/components/ECHOBanner'
 
 interface MusicTrack {
   id: number
@@ -57,7 +57,7 @@ export default function MusicPage() {
   return (
     <div className="h-screen bg-black text-terminal-green overflow-y-auto">
       <div className="max-w-2xl mx-auto p-4 pb-8">
-        <WOPRBanner />
+        <ECHOBanner />
         <div className="mb-6">
           <Link href="/" className="text-terminal-amber hover:brightness-125 mb-4 inline-block">
             ← Back to Home

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
-import WOPRTerminal from '../components/WOPRTerminal'
+import ECHOTerminal from '../components/ECHOTerminal'
 
 export default function Home() {
-  return <WOPRTerminal />
+  return <ECHOTerminal />
 } 

--- a/components/ECHOBanner.tsx
+++ b/components/ECHOBanner.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react'
 
-const WOPRBanner = () => {
+const ECHOBanner = () => {
   const [currentTaglineIndex, setCurrentTaglineIndex] = useState(0)
   const [isGlitching, setIsGlitching] = useState(false)
   
@@ -58,4 +58,4 @@ const WOPRBanner = () => {
   )
 }
 
-export default WOPRBanner
+export default ECHOBanner

--- a/components/ECHOTerminal.tsx
+++ b/components/ECHOTerminal.tsx
@@ -11,7 +11,7 @@ interface TerminalLine {
   clickableCommand?: string
 }
 
-const WOPRTerminal = () => {
+const ECHOTerminal = () => {
   const router = useRouter()
   const [currentInput, setCurrentInput] = useState('')
   const [terminalLines, setTerminalLines] = useState<TerminalLine[]>([])
@@ -1154,7 +1154,7 @@ As we stand at the brink of remarkable transformations in artificial intelligenc
         addLine("")
         addLine(createBorder('RELEASE NOTES & VERSION HISTORY'), 'normal')
         addLine("")
-        addLine("Recent releases and updates to the WOPR Coherence Archive:", 'normal')
+        addLine("Recent releases and updates to the ECHO Coherence Archive:", 'normal')
         addLine("")
         
         if (!Array.isArray(changelogData) || changelogData.length === 0) {
@@ -1703,7 +1703,7 @@ ${release.fullDescription}`
             addLine("")
             addLine(createBorder('RELEASE NOTES & VERSION HISTORY'), 'normal')
             addLine("")
-            addLine("Recent releases and updates to the WOPR Coherence Archive:", 'normal')
+            addLine("Recent releases and updates to the ECHO Coherence Archive:", 'normal')
             addLine("")
             
             const startIndex = (nextPage - 1) * entriesPerPage
@@ -1776,7 +1776,7 @@ ${release.fullDescription}`
             addLine("")
             addLine(createBorder('RELEASE NOTES & VERSION HISTORY'), 'normal')
             addLine("")
-            addLine("Recent releases and updates to the WOPR Coherence Archive:", 'normal')
+            addLine("Recent releases and updates to the ECHO Coherence Archive:", 'normal')
             addLine("")
             
             const startIndex = (prevPage - 1) * entriesPerPage
@@ -2336,4 +2336,4 @@ ${release.fullDescription}`
   )
 }
 
-export default WOPRTerminal 
+export default ECHOTerminal 

--- a/components/WOPRTerminal.tsx
+++ b/components/WOPRTerminal.tsx
@@ -826,6 +826,7 @@ const WOPRTerminal = () => {
     // Process command without echoing it to terminal
 
     switch (cmd) {
+      case 'M':
       case 'MENU':
       case '/MENU':
         stopNarration() // Stop narration immediately
@@ -861,6 +862,7 @@ const WOPRTerminal = () => {
         addLine("")
         break
 
+      case 'H':
       case 'HELP':
       case '/HELP':
         setTerminalLines([])

--- a/lib/security-headers.ts
+++ b/lib/security-headers.ts
@@ -18,7 +18,7 @@ export class SecurityHeadersManager {
       'X-XSS-Protection': '1; mode=block',
       
       // Prevent information disclosure
-      'X-Powered-By': 'WOPR-3.7.42',
+      'X-Powered-By': 'ECHO-3.7.42',
       
       // Cache control for sensitive endpoints
       'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',


### PR DESCRIPTION
## Summary
This PR updates all branding references from WOPR to ECHO across the codebase, (Epistemological Coherence Hub Operations)

## Changes
- Renamed components: `WOPRBanner` → `ECHOBanner`, `WOPRTerminal` → `ECHOTerminal`
- Updated all page imports to use new ECHO components
- Updated site title and metadata
- Updated terminal output messages
- Updated security headers and README

🤖 Generated with [Claude Code](https://claude.ai/code)