### PR TITLE
Fix: numeric '4' navigation + instant menu switches

### DIFF
--- a/components/ECHOTerminal.tsx
+++ b/components/ECHOTerminal.tsx
@@ -840,9 +840,10 @@ const ECHOTerminal = () => {
     setIsDisplayingMarkdown(false)
     
     // Trigger transition effect for navigation commands
-    if (['1', '2', '3', 'X', 'MENU', '/MENU', 'JOURNALS', 'BOOKS', 'ABOUT'].includes(cmd)) {
-      await triggerTransition()
-    }
+    // Disable animated transition for instant switching
+    // if (['1', '2', '3', 'X', 'MENU', '/MENU', 'JOURNALS', 'BOOKS', 'ABOUT'].includes(cmd)) {
+    //   await triggerTransition()
+    // }
     
     // Process command without echoing it to terminal
 
@@ -851,8 +852,7 @@ const ECHOTerminal = () => {
       case 'MENU':
       case '/MENU':
         stopNarration() // Stop narration immediately
-        // Wait for smooth transition (0.5s total)
-        await new Promise(resolve => setTimeout(resolve, 500))
+        // Instant switch: remove transition delay
         setTerminalLines([])
         await new Promise(resolve => setTimeout(resolve, 100))
         setIsViewingContent(false)
@@ -887,8 +887,7 @@ const ECHOTerminal = () => {
       case 'H':
       case 'HELP':
       case '/HELP':
-        // Wait for smooth transition (0.5s total)
-        await new Promise(resolve => setTimeout(resolve, 500))
+        // Instant switch: remove transition delay
         setTerminalLines([])
         await new Promise(resolve => setTimeout(resolve, 100))
         changeMenu('help')
@@ -924,8 +923,7 @@ const ECHOTerminal = () => {
         stopNarration() // Stop narration when navigating to journals
         setCurrentNarrationUrls([]) // Clear narration state
         setCurrentChunkIndex(0)
-        // Wait for smooth transition (0.5s total)
-        await new Promise(resolve => setTimeout(resolve, 500))
+        // Instant switch: remove transition delay
         setTerminalLines([])
         await new Promise(resolve => setTimeout(resolve, 100))
         changeMenu('journals')
@@ -986,8 +984,7 @@ const ECHOTerminal = () => {
         stopNarration() // Stop narration when navigating to books
         setCurrentNarrationUrls([]) // Clear narration state
         setCurrentChunkIndex(0)
-        // Wait for smooth transition (0.5s total)
-        await new Promise(resolve => setTimeout(resolve, 500))
+        // Instant switch: remove transition delay
         setTerminalLines([])
         await new Promise(resolve => setTimeout(resolve, 100))
         changeMenu('books')
@@ -1031,8 +1028,7 @@ const ECHOTerminal = () => {
         stopNarration() // Stop narration when navigating to about
         setCurrentNarrationUrls([]) // Clear narration state
         setCurrentChunkIndex(0)
-        // Wait for smooth transition (0.5s total)
-        await new Promise(resolve => setTimeout(resolve, 500))
+        // Instant switch: remove transition delay
         setTerminalLines([])
         await new Promise(resolve => setTimeout(resolve, 100))
         changeMenu('about')

--- a/components/ECHOTerminal.tsx
+++ b/components/ECHOTerminal.tsx
@@ -1407,6 +1407,8 @@ ${release.fullDescription}`
         break
 
 
+      case '4':
+      case '4.':
       case '5':
       case '5.':
       case '6':


### PR DESCRIPTION
### Fix: Terminal menu navigation and instant view switches

#### Summary
- Correct numeric selection handling for `4` / `4.` so it navigates like other digits.
- Remove animated transitions and delays for instant, flicker-free screen switches.

#### Details
- Numeric input (`'4'`, `'4.'`) now routes through the same handler as other digits, applying the current menu’s logic (journals/books/changelog).
- Transition helper and wait delays were disabled for navigation commands to eliminate visible blinking and lag.

#### Impact
- UX consistency and responsiveness improved.
- No API or data changes.

#### Verification
- From main, journals, books/chapters, and changelog menus: typing `4` or `4.` selects the expected item.
- Exiting or switching menus is immediate, without fade/blink.
